### PR TITLE
Fix CI build and improve README

### DIFF
--- a/NuclidePredictionCurve/README.md
+++ b/NuclidePredictionCurve/README.md
@@ -1,5 +1,5 @@
 <!-- Badges -->
-![CI](https://github.com/tracyphasespace/Quantum-Field-Dynamics/actions/workflows/ci.yml/badge.svg)
+[![CI](https://github.com/tracyphasespace/Quantum-Field-Dynamics/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/tracyphasespace/Quantum-Field-Dynamics/actions/workflows/ci.yml)
 
 
 
@@ -8,7 +8,7 @@
 This folder contains a **minimal, replication-grade** pipeline to reproduce the
 two-parameter law that fits **all 5,842 known isotopes**:
 
-\[ Q(A) = c_1 A^{2/3} + c_2 A \]
+Q(A) = c1·A^(2/3) + c2·A
 
 with **R² ≈ 0.98** on the complete nuclide set, and **R² ≈ 0.998** for stable
 nuclides (refit). The repo includes code and a distilled dataset (`NuMass.csv`)
@@ -19,6 +19,8 @@ so anyone can reproduce the results quickly.
 ## Quickstart
 
 ```bash
+# From repo root
+cd NuclidePredictionCurve
 # 1) (Optional) create and activate a virtual environment
 python -m venv .venv
 # Windows: .venv\Scripts\activate
@@ -79,9 +81,7 @@ compatible with this pipeline.
 ---
 
 ## Citing
-If you use this code or dataset, please cite:
-- *Universal Nuclear Scaling: A Core Compression Law For Isotopes* (preprint)
-  and the GitHub repository.
+See **CITATION.cff** in this folder for citation metadata.
 
 ---
 

--- a/NuclidePredictionCurve/test_fit.py
+++ b/NuclidePredictionCurve/test_fit.py
@@ -10,8 +10,8 @@ OUT = REPO_ROOT / "results_test"
 def test_pipeline_runs_and_writes_artifacts():
     assert DATA.exists(), f"Missing dataset: {DATA}"
     # Run the pipeline
-    cmd = [sys.executable, str(REPO_ROOT / "run_all.py"), "--data", str(DATA), "--outdir", str(OUT)]
-    res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    cmd = [sys.executable, "run_all.py", "--data", "NuMass.csv", "--outdir", str(OUT.name)]
+    res = subprocess.run(cmd, capture_output=True, text=True, check=False, cwd=REPO_ROOT)
     assert res.returncode == 0, f"run_all.py failed:\nSTDOUT:\n{res.stdout}\nSTDERR:\n{res.stderr}"
 
     coeffs_path = OUT / "coefficients.json"


### PR DESCRIPTION
- Modified `test_fit.py` to run the test pipeline with an explicit working directory, resolving a path issue that caused the CI build to fail.
- Updated `NuclidePredictionCurve/README.md` with several improvements:
    - Made the CI badge link to the GitHub Actions workflow.
    - Added `cd NuclidePredictionCurve` to the quickstart instructions.
    - Changed the math formula to plain text for better rendering.
    - Updated the "Citing" section to refer to `CITATION.cff`.